### PR TITLE
Verhindere Fehler in ApplyChanges, falls keine physikalisch übergeordnete Instanz existiert

### DIFF
--- a/SonosPlayer/module.php
+++ b/SonosPlayer/module.php
@@ -290,7 +290,7 @@ class SonosPlayer extends IPSModule
         // Only if IPS is running, check if parameters sould be requested
         // This is required if an instance is newly created, not during startup.
         // During startup this will be handeled by Splitter instance utilizing MessageSink
-        if (IPS_GetKernelRunlevel() == KR_READY) {
+        if ((IPS_GetKernelRunlevel() == KR_READY) && ($this->HasActiveParent())) {
             if ($this->ReadAttributeInteger('AlbumArtHeight') == -1) {
                 $this->SendDataToParent(json_encode([
                     'DataID'         => '{731D7808-F7C4-FA98-2132-0FAB19A802C1}',

--- a/SonosSplitter/module.php
+++ b/SonosSplitter/module.php
@@ -35,6 +35,7 @@ class SonosSplitter extends IPSModule
     public function ApplyChanges()
     {
         $this->RegisterMessage(0, IPS_KERNELSTARTED);
+        $this->RegisterMessage($this->InstanceID, FM_CHILDADDED);
         // Diese Zeile nicht löschen
         parent::ApplyChanges();
 
@@ -127,6 +128,7 @@ class SonosSplitter extends IPSModule
     {
         switch ($Message) {
           case IPS_KERNELSTARTED:
+          case FM_CHILD_ADDED:
             // Set Timer for update Status in all Player instances
             $this->SendDataToChildren(json_encode([
                 'DataID'         => '{36EA4430-7047-C11D-0854-43391B14E0D7}',


### PR DESCRIPTION
Mit dem neuen Umbau der Instanzerstellung der 8.2 wird nun zuerst der Player inklusive ApplyChanges erstellt bevor die Konsole prüft, welche übergeordneten Instanzen in Frage kommen. Damit lässt sich der Player aktuell leider nicht direkt per Konsole erstellen, da bei ApplyChanges fest SendDataToParent aufgerufen wird. Da aber kein Parent existiert, fliegt ein Fehler.

Der PR fügt daher zusätzlich einen Check hinzu, damit die Erstellung durchläuft. Um das alte Verhalten beizubehalten, habe ich darüber hinaus im Splitter eine Reaktion auf FM_CHILD_ADDED hinzugefügt. Wird also (nun im Fluss später) ein Player mit einem Splitter verbunden, schickt der Splitter direkt ein Update raus.

Es wäre super, wenn du den Fix einmal durchschaust und zeitnah rausbringst, da sonst ein Player aktuell in der 8.2 nicht direkt erstellbar ist.